### PR TITLE
Add option to use es6 rather than googmodule

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -8,11 +8,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as fs from "fs";
-import minimist from "minimist";
-import * as path from "path";
-import ts from "typescript";
-import * as tsickle from "tsickle";
+import * as fs from 'fs';
+import minimist from 'minimist';
+import * as path from 'path';
+import ts from 'typescript';
+import * as tsickle from 'tsickle';
 
 /** Tsickle settings passed on the command line. */
 export interface Settings {
@@ -46,32 +46,29 @@ tsickle flags are:
  * Parses the command-line arguments, extracting the tsickle settings and
  * the arguments to pass on to tsc.
  */
-function loadSettingsFromArgs(args: string[]): {
-  settings: Settings;
-  tscArgs: string[];
-} {
+function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: string[]} {
   const settings: Settings = {};
   const parsedArgs = minimist(args);
   for (const flag of Object.keys(parsedArgs)) {
     switch (flag) {
-      case "h":
-      case "help":
+      case 'h':
+      case 'help':
         usage();
         process.exit(0);
         break;
-      case "externs":
+      case 'externs':
         settings.externsPath = parsedArgs[flag];
         break;
-      case "typed":
+      case 'typed':
         settings.isTyped = true;
         break;
-      case "verbose":
+      case 'verbose':
         settings.verbose = true;
         break;
-      case "fatalWarnings":
+      case 'fatalWarnings':
         settings.fatalWarnings = true;
         break;
-      case "_":
+      case '_':
         // This is part of the minimist API, and holds args after the '--'.
         break;
       default:
@@ -81,8 +78,8 @@ function loadSettingsFromArgs(args: string[]): {
     }
   }
   // Arguments after the '--' arg are arguments to tsc.
-  const tscArgs = parsedArgs["_"];
-  return { settings, tscArgs };
+  const tscArgs = parsedArgs['_'];
+  return {settings, tscArgs};
 }
 
 /**
@@ -97,10 +94,10 @@ export function getCommonParentDirectory(fileNames: string[]): string {
     while (thisPath[j] === commonParent[j]) {
       j++;
     }
-    commonParent.length = j; // Truncate without copying the array
+    commonParent.length = j;  // Truncate without copying the array
   }
   if (commonParent.length === 0) {
-    return "/";
+    return '/';
   } else {
     return commonParent.join(path.sep);
   }
@@ -113,64 +110,51 @@ export function getCommonParentDirectory(fileNames: string[]): string {
  *
  * @param args tsc command-line arguments.
  */
-function loadTscConfig(args: string[]): {
-  options: ts.CompilerOptions;
-  fileNames: string[];
-  errors: ts.Diagnostic[];
-} {
+function loadTscConfig(args: string[]):
+    {options: ts.CompilerOptions, fileNames: string[], errors: ts.Diagnostic[]} {
   // Gather tsc options/input files from command line.
-  let { options, fileNames, errors } = ts.parseCommandLine(args);
+  let {options, fileNames, errors} = ts.parseCommandLine(args);
   if (errors.length > 0) {
-    return { options: {}, fileNames: [], errors };
+    return {options: {}, fileNames: [], errors};
   }
 
   // Store file arguments
   const tsFileArguments = fileNames;
 
   // Read further settings from tsconfig.json.
-  const projectDir = options.project || ".";
-  const configFileName = path.join(projectDir, "tsconfig.json");
-  const { config: json, error } = ts.readConfigFile(configFileName, (path) =>
-    fs.readFileSync(path, "utf-8")
-  );
+  const projectDir = options.project || '.';
+  const configFileName = path.join(projectDir, 'tsconfig.json');
+  const {config: json, error} =
+      ts.readConfigFile(configFileName, path => fs.readFileSync(path, 'utf-8'));
   if (error) {
-    return { options: {}, fileNames: [], errors: [error] };
+    return {options: {}, fileNames: [], errors: [error]};
   }
-  ({ options, fileNames, errors } = ts.parseJsonConfigFileContent(
-    json,
-    ts.sys,
-    projectDir,
-    options,
-    configFileName
-  ));
+  ({options, fileNames, errors} =
+       ts.parseJsonConfigFileContent(json, ts.sys, projectDir, options, configFileName));
   if (errors.length > 0) {
-    return { options: {}, fileNames: [], errors };
+    return {options: {}, fileNames: [], errors};
   }
 
   // if file arguments were given to the typescript transpiler then transpile only those files
   fileNames = tsFileArguments.length > 0 ? tsFileArguments : fileNames;
 
-  return { options, fileNames, errors: [] };
+  return {options, fileNames, errors: []};
 }
 
 /**
  * Compiles TypeScript code into Closure-compiler-ready JS.
  */
 export function toClosureJS(
-  options: ts.CompilerOptions,
-  fileNames: string[],
-  settings: Settings,
-  writeFile: ts.WriteFileCallback
-): tsickle.EmitResult {
+    options: ts.CompilerOptions, fileNames: string[], settings: Settings,
+    writeFile: ts.WriteFileCallback): tsickle.EmitResult {
   // Use absolute paths to determine what files to process since files may be imported using
   // relative or absolute paths
-  const absoluteFileNames = fileNames.map((i) => path.resolve(i));
+  const absoluteFileNames = fileNames.map(i => path.resolve(i));
 
   const compilerHost = ts.createCompilerHost(options);
   const program = ts.createProgram(absoluteFileNames, options, compilerHost);
   const filesToProcess = new Set(absoluteFileNames);
-  const rootModulePath =
-    options.rootDir || getCommonParentDirectory(absoluteFileNames);
+  const rootModulePath = options.rootDir || getCommonParentDirectory(absoluteFileNames);
   const transformerHost: tsickle.TsickleHost = {
     rootDirsRelative: (f: string) => f,
     shouldSkipTsickleProcessing: (fileName: string) => {
@@ -178,7 +162,7 @@ export function toClosureJS(
     },
     shouldIgnoreWarningsForPath: (fileName: string) => !settings.fatalWarnings,
     pathToModuleName: (context, fileName) =>
-      tsickle.pathToModuleName(rootModulePath, context, fileName),
+        tsickle.pathToModuleName(rootModulePath, context, fileName),
     fileNameToModuleId: (fileName) => path.relative(rootModulePath, fileName),
     googmodule: false,
     transformDecorators: true,
@@ -186,10 +170,10 @@ export function toClosureJS(
     typeBlackListPaths: new Set(),
     untyped: false,
     logWarning: (warning) =>
-      console.error(ts.formatDiagnostics([warning], compilerHost)),
+        console.error(ts.formatDiagnostics([warning], compilerHost)),
     options,
     generateExtraSuppressions: true,
-    transformDynamicImport: "nodejs",
+    transformDynamicImport: 'nodejs',
   };
   const diagnostics = ts.getPreEmitDiagnostics(program);
   if (diagnostics.length > 0) {
@@ -207,12 +191,10 @@ export function toClosureJS(
 }
 
 function main(args: string[]): number {
-  const { settings, tscArgs } = loadSettingsFromArgs(args);
+  const {settings, tscArgs} = loadSettingsFromArgs(args);
   const config = loadTscConfig(tscArgs);
   if (config.errors.length) {
-    console.error(
-      ts.formatDiagnostics(config.errors, ts.createCompilerHost(config.options))
-    );
+    console.error(ts.formatDiagnostics(config.errors, ts.createCompilerHost(config.options)));
     return 1;
   }
 
@@ -227,30 +209,20 @@ function main(args: string[]): number {
 
   // Run tsickle+TSC to convert inputs to Closure JS files.
   const result = toClosureJS(
-    config.options,
-    config.fileNames,
-    settings,
-    (filePath: string, contents: string) => {
-      fs.mkdirSync(path.dirname(filePath), { recursive: true });
-      fs.writeFileSync(filePath, contents, { encoding: "utf-8" });
-    }
-  );
+      config.options, config.fileNames, settings, (filePath: string, contents: string) => {
+        fs.mkdirSync(path.dirname(filePath), {recursive: true});
+        fs.writeFileSync(filePath, contents, {encoding: 'utf-8'});
+      });
   if (result.diagnostics.length) {
-    console.error(
-      ts.formatDiagnostics(
-        result.diagnostics,
-        ts.createCompilerHost(config.options)
-      )
-    );
+    console.error(ts.formatDiagnostics(result.diagnostics, ts.createCompilerHost(config.options)));
     return 1;
   }
 
   if (settings.externsPath) {
-    fs.mkdirSync(path.dirname(settings.externsPath), { recursive: true });
+    fs.mkdirSync(path.dirname(settings.externsPath), {recursive: true});
     fs.writeFileSync(
-      settings.externsPath,
-      tsickle.getGeneratedExterns(result.externs, config.options.rootDir || "")
-    );
+        settings.externsPath,
+        tsickle.getGeneratedExterns(result.externs, config.options.rootDir || ''));
   }
   return 0;
 }

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -9,9 +9,9 @@
  */
 
 import * as fs from 'fs';
-import * as minimist from 'minimist';
+import { default as minimist } from 'minimist';
 import * as path from 'path';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as tsickle from 'tsickle';
 
 /** Tsickle settings passed on the command line. */
@@ -164,7 +164,7 @@ export function toClosureJS(
     pathToModuleName: (context, fileName) =>
         tsickle.pathToModuleName(rootModulePath, context, fileName),
     fileNameToModuleId: (fileName) => path.relative(rootModulePath, fileName),
-    googmodule: true,
+    googmodule: false,
     transformDecorators: true,
     transformTypesToClosure: true,
     typeBlackListPaths: new Set(),
@@ -198,14 +198,14 @@ function main(args: string[]): number {
     return 1;
   }
 
-  if (config.options.module !== ts.ModuleKind.CommonJS) {
-    // This is not an upstream TypeScript diagnostic, therefore it does not go
-    // through the diagnostics array mechanism.
-    console.error(
-        'tsickle converts TypeScript modules to Closure modules via CommonJS internally. ' +
-        'Set tsconfig.js "module": "commonjs"');
-    return 1;
-  }
+  // if (config.options.module !== ts.ModuleKind.CommonJS) {
+  //   // This is not an upstream TypeScript diagnostic, therefore it does not go
+  //   // through the diagnostics array mechanism.
+  //   console.error(
+  //       'tsickle converts TypeScript modules to Closure modules via CommonJS internally. ' +
+  //       'Set tsconfig.js "module": "commonjs"');
+  //   return 1;
+  // }
 
   // Run tsickle+TSC to convert inputs to Closure JS files.
   const result = toClosureJS(
@@ -227,7 +227,5 @@ function main(args: string[]): number {
   return 0;
 }
 
-// CLI entry point
-if (require.main === module) {
-  process.exit(main(process.argv.splice(2)));
-}
+// Always run this in the CLI mode.
+process.exit(main(process.argv.splice(2)));

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -8,11 +8,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as fs from 'fs';
-import { default as minimist } from 'minimist';
-import * as path from 'path';
-import ts from 'typescript';
-import * as tsickle from 'tsickle';
+import * as fs from "fs";
+import minimist from "minimist";
+import * as path from "path";
+import ts from "typescript";
+import * as tsickle from "tsickle";
 
 /** Tsickle settings passed on the command line. */
 export interface Settings {
@@ -46,29 +46,32 @@ tsickle flags are:
  * Parses the command-line arguments, extracting the tsickle settings and
  * the arguments to pass on to tsc.
  */
-function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: string[]} {
+function loadSettingsFromArgs(args: string[]): {
+  settings: Settings;
+  tscArgs: string[];
+} {
   const settings: Settings = {};
   const parsedArgs = minimist(args);
   for (const flag of Object.keys(parsedArgs)) {
     switch (flag) {
-      case 'h':
-      case 'help':
+      case "h":
+      case "help":
         usage();
         process.exit(0);
         break;
-      case 'externs':
+      case "externs":
         settings.externsPath = parsedArgs[flag];
         break;
-      case 'typed':
+      case "typed":
         settings.isTyped = true;
         break;
-      case 'verbose':
+      case "verbose":
         settings.verbose = true;
         break;
-      case 'fatalWarnings':
+      case "fatalWarnings":
         settings.fatalWarnings = true;
         break;
-      case '_':
+      case "_":
         // This is part of the minimist API, and holds args after the '--'.
         break;
       default:
@@ -78,8 +81,8 @@ function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: str
     }
   }
   // Arguments after the '--' arg are arguments to tsc.
-  const tscArgs = parsedArgs['_'];
-  return {settings, tscArgs};
+  const tscArgs = parsedArgs["_"];
+  return { settings, tscArgs };
 }
 
 /**
@@ -94,10 +97,10 @@ export function getCommonParentDirectory(fileNames: string[]): string {
     while (thisPath[j] === commonParent[j]) {
       j++;
     }
-    commonParent.length = j;  // Truncate without copying the array
+    commonParent.length = j; // Truncate without copying the array
   }
   if (commonParent.length === 0) {
-    return '/';
+    return "/";
   } else {
     return commonParent.join(path.sep);
   }
@@ -110,51 +113,64 @@ export function getCommonParentDirectory(fileNames: string[]): string {
  *
  * @param args tsc command-line arguments.
  */
-function loadTscConfig(args: string[]):
-    {options: ts.CompilerOptions, fileNames: string[], errors: ts.Diagnostic[]} {
+function loadTscConfig(args: string[]): {
+  options: ts.CompilerOptions;
+  fileNames: string[];
+  errors: ts.Diagnostic[];
+} {
   // Gather tsc options/input files from command line.
-  let {options, fileNames, errors} = ts.parseCommandLine(args);
+  let { options, fileNames, errors } = ts.parseCommandLine(args);
   if (errors.length > 0) {
-    return {options: {}, fileNames: [], errors};
+    return { options: {}, fileNames: [], errors };
   }
 
   // Store file arguments
   const tsFileArguments = fileNames;
 
   // Read further settings from tsconfig.json.
-  const projectDir = options.project || '.';
-  const configFileName = path.join(projectDir, 'tsconfig.json');
-  const {config: json, error} =
-      ts.readConfigFile(configFileName, path => fs.readFileSync(path, 'utf-8'));
+  const projectDir = options.project || ".";
+  const configFileName = path.join(projectDir, "tsconfig.json");
+  const { config: json, error } = ts.readConfigFile(configFileName, (path) =>
+    fs.readFileSync(path, "utf-8")
+  );
   if (error) {
-    return {options: {}, fileNames: [], errors: [error]};
+    return { options: {}, fileNames: [], errors: [error] };
   }
-  ({options, fileNames, errors} =
-       ts.parseJsonConfigFileContent(json, ts.sys, projectDir, options, configFileName));
+  ({ options, fileNames, errors } = ts.parseJsonConfigFileContent(
+    json,
+    ts.sys,
+    projectDir,
+    options,
+    configFileName
+  ));
   if (errors.length > 0) {
-    return {options: {}, fileNames: [], errors};
+    return { options: {}, fileNames: [], errors };
   }
 
   // if file arguments were given to the typescript transpiler then transpile only those files
   fileNames = tsFileArguments.length > 0 ? tsFileArguments : fileNames;
 
-  return {options, fileNames, errors: []};
+  return { options, fileNames, errors: [] };
 }
 
 /**
  * Compiles TypeScript code into Closure-compiler-ready JS.
  */
 export function toClosureJS(
-    options: ts.CompilerOptions, fileNames: string[], settings: Settings,
-    writeFile: ts.WriteFileCallback): tsickle.EmitResult {
+  options: ts.CompilerOptions,
+  fileNames: string[],
+  settings: Settings,
+  writeFile: ts.WriteFileCallback
+): tsickle.EmitResult {
   // Use absolute paths to determine what files to process since files may be imported using
   // relative or absolute paths
-  const absoluteFileNames = fileNames.map(i => path.resolve(i));
+  const absoluteFileNames = fileNames.map((i) => path.resolve(i));
 
   const compilerHost = ts.createCompilerHost(options);
   const program = ts.createProgram(absoluteFileNames, options, compilerHost);
   const filesToProcess = new Set(absoluteFileNames);
-  const rootModulePath = options.rootDir || getCommonParentDirectory(absoluteFileNames);
+  const rootModulePath =
+    options.rootDir || getCommonParentDirectory(absoluteFileNames);
   const transformerHost: tsickle.TsickleHost = {
     rootDirsRelative: (f: string) => f,
     shouldSkipTsickleProcessing: (fileName: string) => {
@@ -162,7 +178,7 @@ export function toClosureJS(
     },
     shouldIgnoreWarningsForPath: (fileName: string) => !settings.fatalWarnings,
     pathToModuleName: (context, fileName) =>
-        tsickle.pathToModuleName(rootModulePath, context, fileName),
+      tsickle.pathToModuleName(rootModulePath, context, fileName),
     fileNameToModuleId: (fileName) => path.relative(rootModulePath, fileName),
     googmodule: false,
     transformDecorators: true,
@@ -170,10 +186,10 @@ export function toClosureJS(
     typeBlackListPaths: new Set(),
     untyped: false,
     logWarning: (warning) =>
-        console.error(ts.formatDiagnostics([warning], compilerHost)),
+      console.error(ts.formatDiagnostics([warning], compilerHost)),
     options,
     generateExtraSuppressions: true,
-    transformDynamicImport: 'nodejs',
+    transformDynamicImport: "nodejs",
   };
   const diagnostics = ts.getPreEmitDiagnostics(program);
   if (diagnostics.length > 0) {
@@ -191,10 +207,12 @@ export function toClosureJS(
 }
 
 function main(args: string[]): number {
-  const {settings, tscArgs} = loadSettingsFromArgs(args);
+  const { settings, tscArgs } = loadSettingsFromArgs(args);
   const config = loadTscConfig(tscArgs);
   if (config.errors.length) {
-    console.error(ts.formatDiagnostics(config.errors, ts.createCompilerHost(config.options)));
+    console.error(
+      ts.formatDiagnostics(config.errors, ts.createCompilerHost(config.options))
+    );
     return 1;
   }
 
@@ -209,20 +227,30 @@ function main(args: string[]): number {
 
   // Run tsickle+TSC to convert inputs to Closure JS files.
   const result = toClosureJS(
-      config.options, config.fileNames, settings, (filePath: string, contents: string) => {
-        fs.mkdirSync(path.dirname(filePath), {recursive: true});
-        fs.writeFileSync(filePath, contents, {encoding: 'utf-8'});
-      });
+    config.options,
+    config.fileNames,
+    settings,
+    (filePath: string, contents: string) => {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents, { encoding: "utf-8" });
+    }
+  );
   if (result.diagnostics.length) {
-    console.error(ts.formatDiagnostics(result.diagnostics, ts.createCompilerHost(config.options)));
+    console.error(
+      ts.formatDiagnostics(
+        result.diagnostics,
+        ts.createCompilerHost(config.options)
+      )
+    );
     return 1;
   }
 
   if (settings.externsPath) {
-    fs.mkdirSync(path.dirname(settings.externsPath), {recursive: true});
+    fs.mkdirSync(path.dirname(settings.externsPath), { recursive: true });
     fs.writeFileSync(
-        settings.externsPath,
-        tsickle.getGeneratedExterns(result.externs, config.options.rootDir || ''));
+      settings.externsPath,
+      tsickle.getGeneratedExterns(result.externs, config.options.rootDir || "")
+    );
   }
   return 0;
 }

--- a/demo/demo_exports.ts
+++ b/demo/demo_exports.ts
@@ -1,0 +1,19 @@
+export function foo() {
+  return "foo";
+}
+
+export function bar() {
+  return "bar";
+}
+
+export function baz() {
+  return "baz";
+}
+
+export class MyClass {
+  constructor(private objName: string) {}
+
+  public getName() {
+    return this.objName;
+  }
+}

--- a/demo/demo_exports.ts
+++ b/demo/demo_exports.ts
@@ -6,7 +6,8 @@ export function bar() {
   return "bar";
 }
 
-export function baz() {
+export type SpecialType = string | number;
+export function baz() : SpecialType {
   return "baz";
 }
 

--- a/demo/demo_star_exports.ts
+++ b/demo/demo_star_exports.ts
@@ -1,0 +1,8 @@
+import { MyClass, baz } from "./demo_exports";
+import type { SpecialType } from "./demo_exports";
+
+export * from "./demo_exports";
+
+const myObj = new MyClass("myObj");
+
+const bazValue: SpecialType = baz()

--- a/demo/demo_start_exports.ts
+++ b/demo/demo_start_exports.ts
@@ -1,0 +1,5 @@
+import { MyClass } from "./demo_exports";
+
+export * from "./demo_exports";
+
+const myObj = new MyClass("myObj");

--- a/demo/demo_start_exports.ts
+++ b/demo/demo_start_exports.ts
@@ -1,5 +1,0 @@
-import { MyClass } from "./demo_exports";
-
-export * from "./demo_exports";
-
-const myObj = new MyClass("myObj");

--- a/demo/package.json
+++ b/demo/package.json
@@ -17,5 +17,6 @@
   "scripts": {
     "build": "(cd ../ && yarn build) && tsc",
     "demo": "node --preserve-symlinks build/demo.js -- --outDir `pwd`/tsickle-out"
-  }
+  },
+  "type": "module"
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
+    "rootDir": ".",
+    "target": "ESNext",
+    "module": "ESNext",
     "outDir": "build/",
-    "strict": true
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
   },
   "exclude": [
     "test.ts"

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -1067,7 +1067,7 @@ export function jsdocTransformer(
         // Note that this means tsickle does not report diagnostics for
         // side-effect path imports of JavaScript modules with conflicting
         // provides. That is working as intended.
-        if (!importDecl.importClause || leaveModulesAlone) return importDecl;
+        if (!importDecl.importClause) return importDecl;
 
         const sym = typeChecker.getSymbolAtLocation(importDecl.moduleSpecifier);
         // Scripts do not have a symbol, and neither do unused modules (empty
@@ -1197,7 +1197,17 @@ export function jsdocTransformer(
           if (!isTypeAlias) continue;
           const typeName =
               moduleTypeTranslator.symbolsToAliasedNames.get(aliasedSymbol) || aliasedSymbol.name;
-          const stmt = ts.factory.createExpressionStatement(
+          const stmt = leaveModulesAlone ?
+            ts.factory.createExportDeclaration(
+              undefined,
+              false,
+              ts.factory.createNamedExports([ts.factory.createExportSpecifier(
+                false,
+                undefined,
+                ts.factory.createIdentifier(exportedName)
+              )]),
+            ) 
+          : ts.factory.createExpressionStatement(
               ts.factory.createPropertyAccessExpression(
                   ts.factory.createIdentifier('exports'), exportedName));
           addCommentOn(stmt, [{tagName: 'typedef', type: '!' + typeName}]);

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -36,6 +36,7 @@ import {ModuleTypeTranslator} from './module_type_translator';
 import * as transformerUtil from './transformer_util';
 import {getPreviousDeclaration, isMergedDeclaration, symbolIsValue} from './transformer_util';
 import {isValidClosurePropertyName} from './type_translator';
+import { TsickleHost } from 'tsickle';
 
 function addCommentOn(
     node: ts.Node, tags: jsdoc.Tag[], escapeExtraTags?: Set<string>,
@@ -497,7 +498,7 @@ function containsOptionalChainingOperator(node: ts.PropertyAccessExpression|ts.N
  * JSDoc annotations.
  */
 export function jsdocTransformer(
-    host: AnnotatorHost&GoogModuleProcessorHost, tsOptions: ts.CompilerOptions,
+    host: AnnotatorHost&GoogModuleProcessorHost&TsickleHost, tsOptions: ts.CompilerOptions,
     typeChecker: ts.TypeChecker, diagnostics: ts.Diagnostic[]):
     (context: ts.TransformationContext) => ts.Transformer<ts.SourceFile> {
   return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
@@ -1056,7 +1057,7 @@ export function jsdocTransformer(
         return createClosureCast(node, propertyAccessWithCast, propType);
       }
 
-      function visitImportDeclaration(importDecl: ts.ImportDeclaration) {
+      function visitImportDeclaration(importDecl: ts.ImportDeclaration, leaveModulesAlone = false) {
         // For each import, insert a goog.requireType for the module, so that if
         // TypeScript does not emit the module because it's only used in type
         // positions, the JSDoc comments still reference a valid Closure level
@@ -1066,7 +1067,7 @@ export function jsdocTransformer(
         // Note that this means tsickle does not report diagnostics for
         // side-effect path imports of JavaScript modules with conflicting
         // provides. That is working as intended.
-        if (!importDecl.importClause) return importDecl;
+        if (!importDecl.importClause || leaveModulesAlone) return importDecl;
 
         const sym = typeChecker.getSymbolAtLocation(importDecl.moduleSpecifier);
         // Scripts do not have a symbol, and neither do unused modules (empty
@@ -1126,7 +1127,7 @@ export function jsdocTransformer(
        * visitExportDeclaration requireTypes exported modules and emits explicit exports for
        * types (which normally do not get emitted by TypeScript).
        */
-      function visitExportDeclaration(exportDecl: ts.ExportDeclaration): ts.Node|ts.Node[] {
+      function visitExportDeclaration(exportDecl: ts.ExportDeclaration, leaveModulesAlone = false): ts.Node|ts.Node[] {
         const importedModuleSymbol = exportDecl.moduleSpecifier &&
             typeChecker.getSymbolAtLocation(exportDecl.moduleSpecifier)!;
         if (importedModuleSymbol) {
@@ -1135,7 +1136,8 @@ export function jsdocTransformer(
           moduleTypeTranslator.requireType(
               exportDecl.moduleSpecifier!, (exportDecl.moduleSpecifier as ts.StringLiteral).text,
               importedModuleSymbol,
-              /* default import? */ false);
+              /* default import? */ false, 
+              leaveModulesAlone);
         }
 
         const typesToExport: Array<[string, ts.Symbol]> = [];
@@ -1427,6 +1429,7 @@ export function jsdocTransformer(
       }
 
       function visitor(node: ts.Node): ts.Node|ts.Node[] {
+        const leaveModulesAlone = !host.googmodule && host.transformTypesToClosure
         if (transformerUtil.isAmbient(node)) {
           if (!transformerUtil.hasModifierFlag(node as ts.Declaration, ts.ModifierFlags.Export)) {
             return node;
@@ -1435,9 +1438,9 @@ export function jsdocTransformer(
         }
         switch (node.kind) {
           case ts.SyntaxKind.ImportDeclaration:
-            return visitImportDeclaration(node as ts.ImportDeclaration);
+            return visitImportDeclaration(node as ts.ImportDeclaration, leaveModulesAlone);
           case ts.SyntaxKind.ExportDeclaration:
-            return visitExportDeclaration(node as ts.ExportDeclaration);
+            return visitExportDeclaration(node as ts.ExportDeclaration, leaveModulesAlone);
           case ts.SyntaxKind.ClassDeclaration:
             return visitClassDeclaration(node as ts.ClassDeclaration);
           case ts.SyntaxKind.InterfaceDeclaration:

--- a/src/jsdoc_transformer.ts
+++ b/src/jsdoc_transformer.ts
@@ -1087,7 +1087,7 @@ export function jsdocTransformer(
 
         moduleTypeTranslator.requireType(
             importDecl.moduleSpecifier, importPath, sym,
-            /* default import? */ !!importDecl.importClause.name);
+            /* default import? */ !!importDecl.importClause.name, leaveModulesAlone);
         return importDecl;
       }
 
@@ -1194,20 +1194,10 @@ export function jsdocTransformer(
           }
           const isTypeAlias = (aliasedSymbol.flags & ts.SymbolFlags.Value) === 0 &&
               (aliasedSymbol.flags & (ts.SymbolFlags.TypeAlias | ts.SymbolFlags.Interface)) !== 0;
-          if (!isTypeAlias) continue;
+          if (!isTypeAlias || leaveModulesAlone) continue;
           const typeName =
               moduleTypeTranslator.symbolsToAliasedNames.get(aliasedSymbol) || aliasedSymbol.name;
-          const stmt = leaveModulesAlone ?
-            ts.factory.createExportDeclaration(
-              undefined,
-              false,
-              ts.factory.createNamedExports([ts.factory.createExportSpecifier(
-                false,
-                undefined,
-                ts.factory.createIdentifier(exportedName)
-              )]),
-            ) 
-          : ts.factory.createExpressionStatement(
+          const stmt = ts.factory.createExpressionStatement(
               ts.factory.createPropertyAccessExpression(
                   ts.factory.createIdentifier('exports'), exportedName));
           addCommentOn(stmt, [{tagName: 'typedef', type: '!' + typeName}]);

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -255,7 +255,7 @@ export class ModuleTypeTranslator {
    */
   requireType(
       context: ts.Node, importPath: string, moduleSymbol: ts.Symbol,
-      isDefaultImport = false) {
+      isDefaultImport = false, leaveModulesAlone = false) {
     if (this.host.untyped) return;
     // Already imported? Do not emit a duplicate requireType.
     if (this.requireTypeModules.has(moduleSymbol)) return;
@@ -286,7 +286,18 @@ export class ModuleTypeTranslator {
     // goog.requireType types, which allows using them in type annotations
     // without causing a load.
     //   const requireTypePrefix = goog.requireType(moduleNamespace)
-    this.additionalImports.push(ts.factory.createVariableStatement(
+    this.additionalImports.push(
+      leaveModulesAlone ?
+        ts.factory.createImportDeclaration(
+          undefined,
+          ts.factory.createImportClause(
+            false,
+            undefined,
+            ts.factory.createNamespaceImport(
+              ts.factory.createIdentifier(requireTypePrefix))),
+          ts.factory.createStringLiteral(moduleNamespace)
+        )
+      : ts.factory.createVariableStatement(
         undefined,
         ts.factory.createVariableDeclarationList(
             [ts.factory.createVariableDeclaration(

--- a/src/module_type_translator.ts
+++ b/src/module_type_translator.ts
@@ -295,7 +295,7 @@ export class ModuleTypeTranslator {
             undefined,
             ts.factory.createNamespaceImport(
               ts.factory.createIdentifier(requireTypePrefix))),
-          ts.factory.createStringLiteral(moduleNamespace)
+          ts.factory.createStringLiteral(importPath)
         )
       : ts.factory.createVariableStatement(
         undefined,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,10 +18,11 @@
     "strict": true,
     "outDir": "out",
     "paths": {"tsickle": ["./src/tsickle.ts"]},
+    "esModuleInterop": true
   },
   "include": [
     "src/*.ts",
     "test/*.ts",
     "demo/*.ts"
-  ] 
+  ],
 }


### PR DESCRIPTION
Testing:
 - `yarn install` in the root
 - `yarn link` in the root
 - Go into the demo folder
 - `yarn link tsickle`
 - `npm run build`
 - `npm run demo`
 -  This should create a `demo/tsickle-out` directory
 - Move into that directory
 - Remove the `demo.js` file because we really don't care about the tsickle'd output from it (and it has errors with closure)
 - Run closure via:
   ```
   npx google-closure-compiler \
   --js='*.js' \
   --js_output_file=out.js \
   --source_map_include_content \
   --generate_exports \
   --export_local_property_definitions \
   --language_in=UNSTABLE \
   --module_resolution=NODE
   ```
- This should output an `out.js` file with no errors